### PR TITLE
Update AppDelegate.swift

### DIFF
--- a/iTorrent/System/AppDelegate/AppDelegate.swift
+++ b/iTorrent/System/AppDelegate/AppDelegate.swift
@@ -26,7 +26,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Override point for customization after application launch.
         UIApplication.shared.setMinimumBackgroundFetchInterval(UIApplication.backgroundFetchIntervalMinimum)
 
-        FirebaseApp.configure()
+
         GADMobileAds.sharedInstance().start(completionHandler: nil)
 
         // Crash on iOS 9


### PR DESCRIPTION
build failed because after update `FirebaseApp.configure() ` is not found in new version