### PR TITLE
Fixed torrent remove navigation bug

### DIFF
--- a/iTorrent/ViewControllers/TorrentListController/TorrentListDataSource.swift
+++ b/iTorrent/ViewControllers/TorrentListController/TorrentListDataSource.swift
@@ -31,7 +31,7 @@ class TorrentListDataSource: DiffableDataSource<String, TorrentModel> {
             // if detail view opens with deleted hash, close it
             if let splitViewController = self.controller.splitViewController,
                 !splitViewController.isCollapsed,
-                let nav = splitViewController.viewControllers[1] as? UINavigationController,
+                let nav = splitViewController.viewControllers.last(where: {$0 is UINavigationController}) as? UINavigationController,
                 let detailView = nav.viewControllers.first as? TorrentDetailsController {
                 if hashes.contains(where: { $0 == detailView.managerHash }) {
                     splitViewController.showDetailViewController(Utils.createEmptyViewController(), sender: self)


### PR DESCRIPTION
Fixed navigation issue during torrent removing.
See the [issue report](https://github.com/XITRIX/iTorrent/issues/166)
Steps to reproduce:

1. Add torrent. The details page is empty. 
2. Remove torrent.
3. Observe crash.