### PR TITLE
Fix cold launch crash from magnet: link. 😵‍💫

### DIFF
--- a/iTorrent/System/Engine/Core/Core.swift
+++ b/iTorrent/System/Engine/Core/Core.swift
@@ -35,8 +35,10 @@ class Core: NSObject {
     
     private override init() {
         super.init()
+        
+        TorrentSdk.initEngine(downloadFolder: Core.rootFolder, configFolder: Core.configFolder, settingsPack: SettingsPack.userPrefered)
+        
         DispatchQueue.global(qos: .background).async {
-            TorrentSdk.initEngine(downloadFolder: Core.rootFolder, configFolder: Core.configFolder, settingsPack: SettingsPack.userPrefered)
             self.restoreAllTorrents()
             
             let allocateStorage = UserPreferences.storagePreallocation


### PR DESCRIPTION
Universal Link can trigger downloads.
If app is opend, everything will be fine. Otherwise, booom!  😵‍💫